### PR TITLE
Fix stray comment in app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -526,7 +526,6 @@ const TiempoProduccionApp = () => {
       } else {
         console.log('✅ Guardado en tabla Ejecución');
       }
-      */
       
       // 2. Guardar en nueva tabla Registro_Etapas_Ejecutadas
       const datosEtapa = {


### PR DESCRIPTION
## Summary
- remove stray `*/` that caused syntax errors

## Testing
- `npm run build`
- `npm run start`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68463eea26148324a10fcf1ae6b0b255